### PR TITLE
[ 메뉴 상세 페이지 ] 장바구니 담기 POST API 연결 & 홈으로 이동하기 

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -9,7 +9,7 @@ export default function Router() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<MainPage />} />
-        <Route path="/:menuId" element={<DetailPage />} />
+        <Route path="menu/:menuId" element={<DetailPage />} />
         <Route path="/cart" element={<CartPage />} />
         <Route path="/pay" element={<PayPage />} />
       </Routes>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -9,7 +9,7 @@ export default function Router() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<MainPage />} />
-        <Route path=":menuId" element={<DetailPage />} />
+        <Route path="/:menuId" element={<DetailPage />} />
         <Route path="/cart" element={<CartPage />} />
         <Route path="/pay" element={<PayPage />} />
       </Routes>

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -7,9 +7,10 @@ import Allergy from "../components/common/Allergy";
 import { useParams } from "react-router-dom";
 import { getMenuDetail } from "../util/api";
 import { priceToString } from "../util/priceToString";
+import Counter from "../components/common/Counter";
 
 export interface iDetailInfo {
-  menuId: string;
+  menuId: number;
   menuName: string;
   priceLarge: number;
   priceSet: number;
@@ -17,10 +18,15 @@ export interface iDetailInfo {
   allergy: Array<"pig" | "cow" | "tomato" | "chicken" | "lettuce">;
 }
 
+type HeaderProps = {
+  children: JSX.Element;
+};
+
 export default function DetailPage() {
   const { menuId } = useParams();
+  const [count, setCount] = useState(1);
   const [detailInfo, setDetailInfo] = useState<iDetailInfo>({
-    menuId: "",
+    menuId: 0,
     menuName: "",
     priceLarge: 0,
     priceSet: 0,
@@ -51,60 +57,20 @@ export default function DetailPage() {
 
       <AddSetTitle>세부 항목을 선택하세요</AddSetTitle>
 
-      <AddSetBoard>
-        <AddSetBoardTitleWrap>
-          <AddSetBoardTitle>라지 세트</AddSetBoardTitle>
-        </AddSetBoardTitleWrap>
-
-        <AddSetBoardPrice>₩ {priceToString(detailInfo.priceLarge)}</AddSetBoardPrice>
-        <CountSelectedSetWrap>
-          <RemoveSelectedSetBtn type="button">
-            <RemoveSetImg src={RemoveSet}></RemoveSetImg>
-          </RemoveSelectedSetBtn>
-
-          <CountedSetNum>1</CountedSetNum>
-
-          <AddSelectedSetBtn type="button">
-            <AddSetImg src={AddSet}></AddSetImg>
-          </AddSelectedSetBtn>
-        </CountSelectedSetWrap>
-      </AddSetBoard>
-      <AddSetBoard>
-        <AddSetBoardTitleWrap>
-          <AddSetBoardTitle>세트</AddSetBoardTitle>
-        </AddSetBoardTitleWrap>
-        <AddSetBoardPrice>₩ {priceToString(detailInfo.priceSet)}</AddSetBoardPrice>
-
-        <CountSelectedSetWrap>
-          <RemoveSelectedSetBtn type="button">
-            <RemoveSetImg src={RemoveSet}></RemoveSetImg>
-          </RemoveSelectedSetBtn>
-
-          <CountedSetNum>1</CountedSetNum>
-
-          <AddSelectedSetBtn type="button">
-            <AddSetImg src={AddSet}></AddSetImg>
-          </AddSelectedSetBtn>
-        </CountSelectedSetWrap>
-      </AddSetBoard>
-      <AddSetBoard>
-        <AddSetBoardTitleWrap>
-          <AddSetBoardTitle>단품</AddSetBoardTitle>
-        </AddSetBoardTitleWrap>
-        <AddSetBoardPrice>₩ {priceToString(detailInfo.priceOnly)}</AddSetBoardPrice>
-
-        <CountSelectedSetWrap>
-          <RemoveSelectedSetBtn type="button">
-            <RemoveSetImg src={RemoveSet}></RemoveSetImg>
-          </RemoveSelectedSetBtn>
-
-          <CountedSetNum>1</CountedSetNum>
-
-          <AddSelectedSetBtn type="button">
-            <AddSetImg src={AddSet}></AddSetImg>
-          </AddSelectedSetBtn>
-        </CountSelectedSetWrap>
-      </AddSetBoard>
+      {["라지세트", "세트", "단품"].map((set) => (
+        <AddSetBoard key={set}>
+          <AddSetBoardTitleWrap>
+            <AddSetBoardTitle>{set}</AddSetBoardTitle>
+          </AddSetBoardTitleWrap>
+          <AddSetBoardPrice>
+            ₩{" "}
+            {priceToString(
+              set === "라지세트" ? detailInfo.priceLarge : set === "세트" ? detailInfo.priceSet : detailInfo.priceOnly,
+            )}
+          </AddSetBoardPrice>
+          <Counter count={count} setCount={setCount}></Counter>
+        </AddSetBoard>
+      ))}
 
       <SelectedSetDetail>
         <SelectedSetName>라지 세트 (1)</SelectedSetName>
@@ -254,7 +220,7 @@ const AddSetBoardPrice = styled.div`
 
   font-size: ${theme.fonts.subtitle1};
 
-  margin: 2rem 0rem 2rem 1.1rem;
+  margin: 2rem 4.3rem 2rem 1.1rem;
 
   display: flex;
   align-items: center;

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -49,7 +49,7 @@ export default function DetailPage() {
 
   const handleClick = () => {
     {
-      menuId && postCartAPI(menuId, largeCount, basicSetCount, onlyCount).then((result) => console.log(result));
+      menuId && postCartAPI(menuId, largeCount, basicSetCount, onlyCount);
     }
   };
 

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -2,10 +2,10 @@
 import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import theme from "../styles/theme";
-import { BurgerImage, BackIcon, RemoveSet, AddSet } from "../assets/image/asset";
+import { BurgerImage, BackIcon } from "../assets/image/asset";
 import Allergy from "../components/common/Allergy";
-import { useParams } from "react-router-dom";
-import { getMenuDetail, postCartAPI } from "../util/api";
+import { useNavigate, useParams } from "react-router-dom";
+import { getMenuDetail, postCartAPI, iSetInfo } from "../util/api";
 import { priceToString } from "../util/priceToString";
 import Counter from "../components/common/Counter";
 
@@ -23,6 +23,14 @@ export default function DetailPage() {
   const [largeCount, setLargeCount] = useState(1);
   const [basicSetCount, setBasicSetCount] = useState(0);
   const [onlyCount, setOnlyCount] = useState(0);
+  const navigate = useNavigate();
+
+  // const [orderSetInfo, setOrderSetInfo] = useState<iSetInfo>({
+  //   menuId: 0,
+  //   largeSet: 1,
+  //   basicSet: 0,
+  //   only: 0,
+  // });
 
   const [detailInfo, setDetailInfo] = useState<iDetailInfo>({
     menuId: 0,
@@ -48,7 +56,7 @@ export default function DetailPage() {
   return (
     <DetailBackground>
       <DetailTitle>
-        <DetailBackIcon src={BackIcon}></DetailBackIcon>
+        <DetailBackIcon src={BackIcon} onClick={() => navigate("/")}></DetailBackIcon>
         버거 & 세트
       </DetailTitle>
       <DetailDividingLine></DetailDividingLine>
@@ -80,6 +88,14 @@ export default function DetailPage() {
           ) : (
             <Counter count={onlyCount} setCount={setOnlyCount}></Counter>
           )}
+
+          {/* {set === "라지세트" ? (
+            <Counter count={orderSetInfo.largeSet} setCount={setOrderSetInfo}></Counter>
+          ) : set === "세트" ? (
+            <Counter count={orderSetInfo.basicSet} setCount={setOrderSetInfo}></Counter>
+          ) : (
+            <Counter count={orderSetInfo.only} setCount={setOrderSetInfo}></Counter>
+          )} */}
         </AddSetBoard>
       ))}
 

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -5,7 +5,7 @@ import theme from "../styles/theme";
 import { BurgerImage, BackIcon, RemoveSet, AddSet } from "../assets/image/asset";
 import Allergy from "../components/common/Allergy";
 import { useParams } from "react-router-dom";
-import { getMenuDetail } from "../util/api";
+import { getMenuDetail, postCartAPI } from "../util/api";
 import { priceToString } from "../util/priceToString";
 import Counter from "../components/common/Counter";
 
@@ -18,13 +18,12 @@ export interface iDetailInfo {
   allergy: Array<"pig" | "cow" | "tomato" | "chicken" | "lettuce">;
 }
 
-type HeaderProps = {
-  children: JSX.Element;
-};
-
 export default function DetailPage() {
   const { menuId } = useParams();
-  const [count, setCount] = useState(1);
+  const [largeCount, setLargeCount] = useState(1);
+  const [basicSetCount, setBasicSetCount] = useState(0);
+  const [onlyCount, setOnlyCount] = useState(0);
+
   const [detailInfo, setDetailInfo] = useState<iDetailInfo>({
     menuId: 0,
     menuName: "",
@@ -39,6 +38,12 @@ export default function DetailPage() {
       menuId && getMenuDetail(menuId).then((result) => setDetailInfo(result.data));
     }
   }, [menuId]);
+
+  const handleClick = () => {
+    {
+      menuId && postCartAPI(menuId, largeCount, basicSetCount, onlyCount).then((result) => console.log(result));
+    }
+  };
 
   return (
     <DetailBackground>
@@ -68,7 +73,13 @@ export default function DetailPage() {
               set === "라지세트" ? detailInfo.priceLarge : set === "세트" ? detailInfo.priceSet : detailInfo.priceOnly,
             )}
           </AddSetBoardPrice>
-          <Counter count={count} setCount={setCount}></Counter>
+          {set === "라지세트" ? (
+            <Counter count={largeCount} setCount={setLargeCount}></Counter>
+          ) : set === "세트" ? (
+            <Counter count={basicSetCount} setCount={setBasicSetCount}></Counter>
+          ) : (
+            <Counter count={onlyCount} setCount={setOnlyCount}></Counter>
+          )}
         </AddSetBoard>
       ))}
 
@@ -91,7 +102,9 @@ export default function DetailPage() {
           <AddToCartSetName>라지 세트 (1)</AddToCartSetName>
           <AddToCartSetPrice>₩ {priceToString(detailInfo.priceLarge)}</AddToCartSetPrice>
         </AddToCartSetInfoWrap>
-        <AddToCartButton type="button">장바구니에 담기</AddToCartButton>
+        <AddToCartButton type="button" onClick={handleClick}>
+          장바구니에 담기
+        </AddToCartButton>
       </AddToCartModal>
     </DetailBackground>
   );

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -1,12 +1,38 @@
 // 메뉴 상세보기 페이지
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import theme from "../styles/theme";
 import { BurgerImage, BackIcon, RemoveSet, AddSet } from "../assets/image/asset";
 import Allergy from "../components/common/Allergy";
+import { useParams } from "react-router-dom";
+import { getMenuDetail } from "../util/api";
+import { priceToString } from "../util/priceToString";
+
+export interface iDetailInfo {
+  menuId: string;
+  menuName: string;
+  priceLarge: number;
+  priceSet: number;
+  priceOnly: number;
+  allergy: Array<"pig" | "cow" | "tomato" | "chicken" | "lettuce">;
+}
 
 export default function DetailPage() {
-  const data: Array<"pig" | "cow" | "tomato" | "chicken" | "lettuce"> = ["pig", "cow", "chicken", "lettuce"];
+  const { menuId } = useParams();
+  const [detailInfo, setDetailInfo] = useState<iDetailInfo>({
+    menuId: "",
+    menuName: "",
+    priceLarge: 0,
+    priceSet: 0,
+    priceOnly: 0,
+    allergy: [],
+  });
+
+  useEffect(() => {
+    {
+      menuId && getMenuDetail(menuId).then((result) => setDetailInfo(result.data));
+    }
+  }, [menuId]);
 
   return (
     <DetailBackground>
@@ -17,9 +43,9 @@ export default function DetailPage() {
       <DetailDividingLine></DetailDividingLine>
       <DetailMenuImg src={BurgerImage} alt="트리플 치즈 버거 이미지"></DetailMenuImg>
       <DetailInfoBoard>
-        <DetailMenuName>트리플 치즈 버거</DetailMenuName>
+        <DetailMenuName>{detailInfo.menuName}</DetailMenuName>
         <DetailAllergyInfo>
-          <Allergy allergyData={data} />
+          <Allergy allergyData={detailInfo.allergy} />
         </DetailAllergyInfo>
       </DetailInfoBoard>
 
@@ -30,7 +56,7 @@ export default function DetailPage() {
           <AddSetBoardTitle>라지 세트</AddSetBoardTitle>
         </AddSetBoardTitleWrap>
 
-        <AddSetBoardPrice>₩ 9,900</AddSetBoardPrice>
+        <AddSetBoardPrice>₩ {priceToString(detailInfo.priceLarge)}</AddSetBoardPrice>
         <CountSelectedSetWrap>
           <RemoveSelectedSetBtn type="button">
             <RemoveSetImg src={RemoveSet}></RemoveSetImg>
@@ -47,7 +73,7 @@ export default function DetailPage() {
         <AddSetBoardTitleWrap>
           <AddSetBoardTitle>세트</AddSetBoardTitle>
         </AddSetBoardTitleWrap>
-        <AddSetBoardPrice>₩ 9,300</AddSetBoardPrice>
+        <AddSetBoardPrice>₩ {priceToString(detailInfo.priceSet)}</AddSetBoardPrice>
 
         <CountSelectedSetWrap>
           <RemoveSelectedSetBtn type="button">
@@ -65,7 +91,7 @@ export default function DetailPage() {
         <AddSetBoardTitleWrap>
           <AddSetBoardTitle>단품</AddSetBoardTitle>
         </AddSetBoardTitleWrap>
-        <AddSetBoardPrice>₩ 7,500</AddSetBoardPrice>
+        <AddSetBoardPrice>₩ {priceToString(detailInfo.priceOnly)}</AddSetBoardPrice>
 
         <CountSelectedSetWrap>
           <RemoveSelectedSetBtn type="button">
@@ -97,7 +123,7 @@ export default function DetailPage() {
         </AddToCartPriceWrap>
         <AddToCartSetInfoWrap>
           <AddToCartSetName>라지 세트 (1)</AddToCartSetName>
-          <AddToCartSetPrice>₩ 9,900</AddToCartSetPrice>
+          <AddToCartSetPrice>₩ {priceToString(detailInfo.priceLarge)}</AddToCartSetPrice>
         </AddToCartSetInfoWrap>
         <AddToCartButton type="button">장바구니에 담기</AddToCartButton>
       </AddToCartModal>

--- a/src/util/api.ts
+++ b/src/util/api.ts
@@ -1,6 +1,13 @@
 // api 모듈을 선언하는 파일입니다
 import axios from "axios";
 
+export interface iSetInfo {
+  menuId: number;
+  largeSet: number;
+  basicSet: number;
+  only: number;
+}
+
 // 장바구니 조회 GET API
 export const getCartAPI = async () => {
   try {
@@ -22,10 +29,11 @@ export const getMenuDetail = async (menuId: string) => {
 };
 
 // 장바구니 담기 POST API
-export const postCartAPI = async (menuId: string, large: number, basicSet: number, only: number) => {
+
+export const postCartAPI = async (menuId: string, largeSet: number, basicSet: number, only: number) => {
   try {
     const res = await axios.post(`/cart/${menuId}`, {
-      largeSet: large,
+      largeSet: largeSet,
       set: basicSet,
       only: only,
     });
@@ -34,3 +42,16 @@ export const postCartAPI = async (menuId: string, large: number, basicSet: numbe
     console.log(error);
   }
 };
+
+// export const postCartAPI = async ({ menuId, largeSet, basicSet, only }: iSetInfo) => {
+//   try {
+//     const res = await axios.post(`/cart/${menuId}`, {
+//       largeSet: largeSet,
+//       set: basicSet,
+//       only: only,
+//     });
+//     return res;
+//   } catch (error) {
+//     console.log(error);
+//   }
+// };

--- a/src/util/api.ts
+++ b/src/util/api.ts
@@ -10,3 +10,13 @@ export const getCartAPI = async () => {
     console.log(error);
   }
 };
+
+//메뉴 상세 페이지 조회 GET API
+export const getMenuDetail = async (menuId: string) => {
+  try {
+    const res = await axios.get(`/menu/${menuId}`);
+    return res.data;
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/src/util/api.ts
+++ b/src/util/api.ts
@@ -20,3 +20,17 @@ export const getMenuDetail = async (menuId: string) => {
     console.log(error);
   }
 };
+
+// 장바구니 담기 POST API
+export const postCartAPI = async (menuId: string, large: number, basicSet: number, only: number) => {
+  try {
+    const res = await axios.post(`/cart/${menuId}`, {
+      largeSet: large,
+      set: basicSet,
+      only: only,
+    });
+    return res;
+  } catch (error) {
+    console.log(error);
+  }
+};


### PR DESCRIPTION
close #42 

- 장바구니 버튼을 누르면 서버로 정보가 post 되어 장바구니에 아이템이 담기는 기능을 구현하였습니다. 
```
export const postCartAPI = async (menuId: string, largeSet: number, basicSet: number, only: number) => {
  try {
    const res = await axios.post(`/cart/${menuId}`, {
      largeSet: largeSet,
      set: basicSet,
      only: only,
    });
    return res;
  } catch (error) {
    console.log(error);
  }
};
```
```
 const handleClick = () => {
    {
      menuId && postCartAPI(menuId, largeCount, basicSetCount, onlyCount);
    }
  };
```
&#8594; 함수 인자 부분을 인터페이스 형식으로 바꾸면 좋을 것 같아서 인터페이스 형식으로 수정하고 detailPage.tsx에서 state를 해당 인터페이스의 형태로 수정하던 중, 공용컴포넌트인 counter와 타입이 맞지 않아 발생하는 이슈가 있어 일단 해당 부분 주석처리하고 pr 날립니다! 은형이가 다시 한 번 봐주기로 했어요!


- 화면 상단 뒤로 가기 버튼을 누르면 홈으로 navigate 되는 기능도 해당 브랜치에서 작업하였습니다. 
```
<DetailBackIcon src={BackIcon} onClick={() => navigate("/")}></DetailBackIcon>
```

https://user-images.githubusercontent.com/63237389/203759431-2de7bad8-828e-45f2-bece-99b437051e3d.mov


